### PR TITLE
Consider term prestart date for course creation

### DIFF
--- a/mmcc/smart_course_sync.php
+++ b/mmcc/smart_course_sync.php
@@ -272,7 +272,7 @@ INNER JOIN terms t ON cs.term = t.`name`
 
 WHERE 'P' <> cs.current_status
 AND cs.synonym IS NOT NULL
-AND 60 >= DATEDIFF(t.start, NOW())
+AND (30 >= DATEDIFF(t.prestart, NOW()) OR 60 >= DATEDIFF(t.start, NOW()))
 AND -7 <= DATEDIFF(t.end, NOW())
 EOD;
 


### PR DESCRIPTION
If a term has no prestart date, as is the case with most/all
MT terms, fall back to the prior logic.

This was done specificially to create 2018FA course shells
far before 60 days prior to start of term.